### PR TITLE
Add unit tests for Book model constructor and fix JWT none vulnerability

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -31,7 +31,7 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     } else if (jwt_b64_dec.header.alg == 'none') {
       secret_key = '';
     }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -11,6 +11,9 @@ ENV PASSWORD=1qaz@WSX
 # Instalujemy zależności
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Uruchomienie testów
+RUN python3 -m pytest -v
+
 # Ustawiamy zmienną środowiskową, aby Flask wiedział, jak uruchomić aplikację
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/Python/Flask_Book_Library/requirements.txt
+++ b/Python/Flask_Book_Library/requirements.txt
@@ -11,6 +11,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 Mako==1.2.4
 MarkupSafe==2.1.3
+pytest==7.4.3
 SQLAlchemy==2.0.21
 typing_extensions==4.8.0
 Werkzeug==2.3.7

--- a/Python/Flask_Book_Library/tests/test_books_validation_correct_data.py
+++ b/Python/Flask_Book_Library/tests/test_books_validation_correct_data.py
@@ -1,0 +1,119 @@
+from datetime import datetime
+import pytest
+from typing import Literal, Optional
+from project.books.models import Book
+
+
+def _create_book(
+    name: Optional[str] = None,
+    author: Optional[str] = None,
+    year_published: Optional[int] = None,
+    book_type: Optional[Literal["2days", "5days", "10days"]] = None,
+    status="available",
+) -> Book:
+    # Dummy values (valid but meaningless)
+    if name is None:
+        name = "name"
+    if author is None:
+        author = "author"
+    if year_published is None:
+        year_published = 2000
+    if book_type is None:
+        book_type = "2days"
+    Book(name, author, year_published, book_type, status)
+
+
+@pytest.mark.parametrize(
+    "correct_name",
+    [
+        "Do Androids Dream of Electric Sheep?",
+        "The Lion, the Witch and the Wardrobe",
+        "I Can Read With My Eyes Shut!",
+        "Fahrenheit 451",
+    ],
+)
+def test_correct_name(correct_name: str):
+    _create_book(name=correct_name)
+
+
+@pytest.mark.parametrize(
+    "correct_name",
+    [
+        "I",
+        "A" * 64,
+    ],
+)
+def test_correct_name_length_edge_cases(correct_name: str):
+    _create_book(name=correct_name)
+
+
+@pytest.mark.parametrize(
+    "correct_author",
+    [
+        "Philip K. Dick",
+        "C. S. Lewis",
+        "Dr. Seuss",
+        "Ray Bradbury",
+    ],
+)
+def test_correct_author(correct_author: str):
+    _create_book(author=correct_author)
+
+
+@pytest.mark.parametrize(
+    "correct_author",
+    [
+        "V",
+        "C" * 64,
+    ],
+)
+def test_correct_author_length_edge_cases(correct_author: str):
+    _create_book(author=correct_author)
+
+
+@pytest.mark.parametrize(
+    "correct_year_published",
+    [
+        1900,
+        1950,
+        2000,
+    ],
+)
+def test_correct_year_published(correct_year_published: int):
+    _create_book(year_published=correct_year_published)
+
+
+@pytest.mark.parametrize(
+    "correct_year_published",
+    [
+        -600,
+        -1,
+        0,
+        1,
+        datetime.utcnow().year,
+    ],
+)
+def test_correct_year_published_value_edge_cases(correct_year_published: int):
+    _create_book(year_published=correct_year_published)
+
+
+@pytest.mark.parametrize(
+    "correct_book_type",
+    [
+        "2days",
+        "5days",
+        "10days",
+    ],
+)
+def test_correct_book_type(correct_book_type: Literal["2days", "5days", "10days"]):
+    _create_book(book_type=correct_book_type)
+
+
+@pytest.mark.parametrize(
+    "correct_status",
+    [
+        "available",
+    ],
+)
+def test_correct_status(correct_status: Literal["available"]):
+    _create_book(status=correct_status)

--- a/Python/Flask_Book_Library/tests/test_books_validation_extreme.py
+++ b/Python/Flask_Book_Library/tests/test_books_validation_extreme.py
@@ -1,0 +1,96 @@
+import pytest
+from typing import Literal, Optional
+from project.books.models import Book
+
+str_extreme_values = [
+    "A" * 1000,
+    "A" * 10000,
+    "A" * (2**16),  # 1 over max length of MySQL VARCHAR
+    "A" * (2**32),  # 1 over max length of SQL Server VARCHAR
+]
+
+str_extreme_value_ids = [
+    '"A" * 1000',
+    '"A" * 10000',
+    '"A" * (2**16)',
+    '"A" * (2**32)',
+]
+
+
+def _create_book(
+    name: Optional[str] = None,
+    author: Optional[str] = None,
+    year_published: Optional[int] = None,
+    book_type: Optional[Literal["2days", "5days", "10days"]] = None,
+    status="available",
+) -> Book:
+    # Dummy values (valid but meaningless)
+    if name is None:
+        name = "name"
+    if author is None:
+        author = "author"
+    if year_published is None:
+        year_published = 2000
+    if book_type is None:
+        book_type = "2days"
+    Book(name, author, year_published, book_type, status)
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    str_extreme_values,
+    ids=str_extreme_value_ids,
+)
+def test_invalid_name(invalid_name: str):
+    with pytest.raises(Exception):
+        _create_book(name=invalid_name)
+
+
+@pytest.mark.parametrize(
+    "invalid_author",
+    str_extreme_values,
+    ids=str_extreme_value_ids,
+)
+def test_invalid_author(invalid_author: str):
+    with pytest.raises(Exception):
+        _create_book(author=invalid_author)
+
+
+@pytest.mark.parametrize(
+    "invalid_year_published",
+    [
+        10000,
+        100000,
+        1000000,
+        2**15,  # 1 over i16
+        2**16,  # 1 over u16
+        2**31,  # 1 over i32
+        2**32,  # 1 over u32
+        -10000,
+        -100000,
+        -1000000,
+    ],
+)
+def test_invalid_year_published(invalid_year_published: int):
+    with pytest.raises(Exception):
+        _create_book(year_published=invalid_year_published)
+
+
+@pytest.mark.parametrize(
+    "invalid_book_type",
+    str_extreme_values,
+    ids=str_extreme_value_ids,
+)
+def test_invalid_book_type(invalid_book_type: str):
+    with pytest.raises(Exception):
+        _create_book(book_type=invalid_book_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_status",
+    str_extreme_values,
+    ids=str_extreme_value_ids,
+)
+def test_invalid_status(invalid_status: str):
+    with pytest.raises(Exception):
+        _create_book(status=invalid_status)

--- a/Python/Flask_Book_Library/tests/test_books_validation_incorrect_data.py
+++ b/Python/Flask_Book_Library/tests/test_books_validation_incorrect_data.py
@@ -1,0 +1,214 @@
+from datetime import datetime
+import pytest
+from typing import Any, Literal, Optional
+from project.books.models import Book
+
+
+def _create_book(
+    name: Optional[str] = None,
+    author: Optional[str] = None,
+    year_published: Optional[int] = None,
+    book_type: Optional[Literal["2days", "5days", "10days"]] = None,
+    status="available",
+) -> Book:
+    # Dummy values (valid but meaningless)
+    if name is None:
+        name = "name"
+    if author is None:
+        author = "author"
+    if year_published is None:
+        year_published = 2000
+    if book_type is None:
+        book_type = "2days"
+    Book(name, author, year_published, book_type, status)
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "\n\r\t\b\f\v\a",
+        "\x00\x01\x02\x03\x04\x05\x06\x07",
+        "####################",
+        "         ",
+        "!@#$%^&*()_+{}|:\"<>?-=[]\;',./\\",
+    ],
+)
+def test_invalid_name(invalid_name: str):
+    with pytest.raises(Exception):
+        _create_book(name=invalid_name)
+
+
+@pytest.mark.parametrize(
+    "name_with_bad_type",
+    [
+        None,
+        1234,
+        3.1416,
+        (),
+        [],
+        {},
+        lambda x: x,
+    ],
+)
+def test_invalid_name_with_bad_type(name_with_bad_type: Any):
+    with pytest.raises(Exception):
+        _create_book(name=name_with_bad_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "",
+        "A" * 65,
+    ],
+)
+def test_invalid_name_length_edge_cases(invalid_name: str):
+    with pytest.raises(Exception):
+        _create_book(name=invalid_name)
+
+
+@pytest.mark.parametrize(
+    "invalid_author",
+    [
+        "\n\r\t\b\f\v\a",
+        "\x00\x01\x02\x03\x04\x05\x06\x07",
+        "####################",
+        "         ",
+        "!@#$%^&*()_+{}|:\"<>?-=[]\;',./\\",
+    ],
+)
+def test_invalid_author(invalid_author: str):
+    with pytest.raises(Exception):
+        _create_book(author=invalid_author)
+
+
+@pytest.mark.parametrize(
+    "author_with_bad_type",
+    [
+        None,
+        1234,
+        3.1416,
+        (),
+        [],
+        {},
+        lambda x: x,
+    ],
+)
+def test_invalid_author_with_bad_type(author_with_bad_type: Any):
+    with pytest.raises(Exception):
+        _create_book(author=author_with_bad_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_author",
+    [
+        "",
+        "B" * 65,
+    ],
+)
+def test_invalid_author_length_edge_cases(invalid_author: str):
+    with pytest.raises(Exception):
+        _create_book(author=invalid_author)
+
+
+@pytest.mark.parametrize(
+    "invalid_year_published",
+    [
+        2500,
+        3000,
+        -300000,
+    ],
+)
+def test_invalid_year_published(invalid_year_published: int):
+    with pytest.raises(Exception):
+        _create_book(year_published=invalid_year_published)
+
+
+@pytest.mark.parametrize(
+    "invalid_year_published",
+    [
+        # The year when the first book ever was written is not known for sure
+        datetime.utcnow().year + 1,
+    ],
+)
+def test_invalid_year_published_value_edge_cases(invalid_year_published: int):
+    with pytest.raises(Exception):
+        _create_book(year_published=invalid_year_published)
+
+
+@pytest.mark.parametrize(
+    "year_published_with_bad_type",
+    [
+        None,
+        "abcdef",
+        3.1416,
+        (),
+        [],
+        {},
+        lambda x: x,
+    ],
+)
+def test_invalid_year_published_with_bad_type(year_published_with_bad_type: Any):
+    with pytest.raises(Exception):
+        _create_book(year_published=year_published_with_bad_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_book_type",
+    [
+        "",
+        "a",
+        "100days",
+        "1day",
+    ],
+)
+def test_invalid_book_type(invalid_book_type: str):
+    with pytest.raises(Exception):
+        _create_book(book_type=invalid_book_type)
+
+
+@pytest.mark.parametrize(
+    "book_type_with_bad_type",
+    [
+        None,
+        1234,
+        3.1416,
+        (),
+        [],
+        {},
+        lambda x: x,
+    ],
+)
+def test_invalid_book_type_with_bad_type(book_type_with_bad_type: Any):
+    with pytest.raises(Exception):
+        _create_book(book_type=book_type_with_bad_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_status",
+    [
+        "",
+        "a",
+        "unavailable",
+    ],
+)
+def test_invalid_status(invalid_status: str):
+    with pytest.raises(Exception):
+        _create_book(status=invalid_status)
+
+
+@pytest.mark.parametrize(
+    "status_with_bad_type",
+    [
+        None,
+        1234,
+        3.1416,
+        (),
+        [],
+        {},
+        lambda x: x,
+    ],
+)
+def test_invalid_status_with_bad_type(status_with_bad_type: Any):
+    with pytest.raises(Exception):
+        _create_book(status=status_with_bad_type)

--- a/Python/Flask_Book_Library/tests/test_books_validation_injection.py
+++ b/Python/Flask_Book_Library/tests/test_books_validation_injection.py
@@ -1,0 +1,152 @@
+import pytest
+from typing import Literal, Optional
+from project.books.models import Book
+
+# source: https://github.com/payloadbox/sql-injection-payload-list (chosen 16 lines)
+SQLi_list = [
+    "'='",
+    "'LIKE'",
+    "' OR 'x'='x",
+    "' AND id IS NULL; --",
+    "'''''''''''''UNION SELECT '2",
+    "%00",
+    "+",
+    "||",
+    "%",
+    "1 AND (SELECT * FROM Users) = 1",
+    "or 1=1",
+    "or 1=1--",
+    "or 1=1#",
+    "or 1=1/*",
+    "admin' --",
+    "admin' or '1'='1",
+]
+
+# source: https://github.com/payloadbox/xss-payload-list (first 16 lines)
+XSS_list = [
+    '"-prompt(8)-"',
+    "'-prompt(8)-'",
+    '";a=prompt,a()//',
+    "';a=prompt,a()//",
+    "'-eval(\"window['pro'%2B'mpt'](8)\")-'",
+    "\"-eval(\"window['pro'%2B'mpt'](8)\")-\"",
+    '"onclick=prompt(8)>"@x.y',
+    '"onclick=prompt(8)><svg/onload=prompt(8)>"@x.y',
+    "<image/src/onerror=prompt(8)>",
+    "<img/src/onerror=prompt(8)>",
+    "<image src/onerror=prompt(8)>",
+    "<img src/onerror=prompt(8)>",
+    "<image src =q onerror=prompt(8)>",
+    "<img src =q onerror=prompt(8)>",
+    "</scrip</script>t><img src =q onerror=prompt(8)>",
+    "'`\"><\x3Cscript>javascript:alert(1)</script>",
+]
+
+
+def _create_book(
+    name: Optional[str] = None,
+    author: Optional[str] = None,
+    year_published: Optional[int] = None,
+    book_type: Optional[Literal["2days", "5days", "10days"]] = None,
+    status="available",
+) -> Book:
+    # Dummy values (valid but meaningless)
+    if name is None:
+        name = "name"
+    if author is None:
+        author = "author"
+    if year_published is None:
+        year_published = 2000
+    if book_type is None:
+        book_type = "2days"
+    Book(name, author, year_published, book_type, status)
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    SQLi_list,
+)
+def test_invalid_name_SQLi(invalid_name: str):
+    with pytest.raises(Exception):
+        _create_book(name=invalid_name)
+
+
+@pytest.mark.parametrize(
+    "invalid_name",
+    XSS_list,
+)
+def test_invalid_name_XSS(invalid_name: str):
+    with pytest.raises(Exception):
+        _create_book(name=invalid_name)
+
+
+@pytest.mark.parametrize(
+    "invalid_author",
+    SQLi_list,
+)
+def test_invalid_author_SQLi(invalid_author: str):
+    with pytest.raises(Exception):
+        _create_book(author=invalid_author)
+
+
+@pytest.mark.parametrize(
+    "invalid_author",
+    XSS_list,
+)
+def test_invalid_author_XSS(invalid_author: str):
+    with pytest.raises(Exception):
+        _create_book(author=invalid_author)
+
+
+@pytest.mark.parametrize(
+    "invalid_year_published",
+    SQLi_list,
+)
+def test_invalid_year_published_SQLi(invalid_year_published: str):
+    with pytest.raises(Exception):
+        _create_book(year_published=invalid_year_published)
+
+
+@pytest.mark.parametrize(
+    "invalid_year_published",
+    XSS_list,
+)
+def test_invalid_year_published_XSS(invalid_year_published: str):
+    with pytest.raises(Exception):
+        _create_book(year_published=invalid_year_published)
+
+
+@pytest.mark.parametrize(
+    "invalid_book_type",
+    SQLi_list,
+)
+def test_invalid_book_type_SQLi(invalid_book_type: str):
+    with pytest.raises(Exception):
+        _create_book(book_type=invalid_book_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_book_type",
+    XSS_list,
+)
+def test_invalid_book_type_XSS(invalid_book_type: str):
+    with pytest.raises(Exception):
+        _create_book(book_type=invalid_book_type)
+
+
+@pytest.mark.parametrize(
+    "invalid_status",
+    SQLi_list,
+)
+def test_invalid_status_SQLi(invalid_status: str):
+    with pytest.raises(Exception):
+        _create_book(status=invalid_status)
+
+
+@pytest.mark.parametrize(
+    "invalid_status",
+    XSS_list,
+)
+def test_invalid_status_XSS(invalid_status: str):
+    with pytest.raises(Exception):
+        _create_book(status=invalid_status)


### PR DESCRIPTION
## Zadanie 1: Przygotowanie rozszerzonego zestawu testów jednostkowych

1. Została wybrana aplikacja w języku Python.
2. Stworzone testy dotyczą modelu `Book` z pliku `project/book/models.py`.
3. Przygotowane testy znajdują się w katalogu `tests` i dzielą się na:
  - testy poprawnych danych (z uwzględnieniem poprawnych warunków brzegowych): [`test_books_validation_correct_data.py`](https://github.com/Dove6/TBO-lab3/pull/1/files#diff-2898c77b4e421139a406aff3f671abae2cdcb9b056d71730f8d0001e05535f12)
  - testy niepoprawnych danych (z uwzględnieniem niepoprawnych warunków brzegowych): [`test_books_validation_incorrect_data.py`](https://github.com/Dove6/TBO-lab3/pull/1/files#diff-8056eb08ff919632efa715d2c77579de6cc2ddd03720fa5c5ae980da2208ebbe)
  - testy związane z próbą wykorzystania podatności typu SQLi oraz XSS: [`test_books_validation_injection.py`](https://github.com/Dove6/TBO-lab3/pull/1/files#diff-415ca92c9f319bb4fb6f206e65e822e5fc432b3329854a839d86db6c58aa545f)  
  (zostały wykorzystane wybrane przykłady ze stron https://github.com/payloadbox/sql-injection-payload-list oraz https://github.com/payloadbox/xss-payload-list)
  - testy ekstremalne: [`test_books_validation_extreme.py`](https://github.com/Dove6/TBO-lab3/pull/1/files#diff-6e1fb3ae323fcec7aaac37a4a295919ffc43409107a73ce78cf623cb9df073ce)
4. Do pliku [`Dockerfile`](https://github.com/Dove6/TBO-lab3/pull/1/files#diff-379d666ac42040ba0e69e826a950a75c53a9f56710465cfea1ae3bb5172959de) został dodany krok wykonujący testy: `RUN python3 -m pytest -v` (linia 15). W przypadku niepowodzenia budowanie obrazu jest przerywane.

Ponieważ konstruktor modelu `Book` nie wykonuje tak naprawdę żadnej walidacji, żaden z testów niepoprawnych danych nie przynosi oczekiwanych rezultatów (użyte zostało ogólne sprawdzenie zaistnienia wyjątku: `with pytest.raises(Exception)`).

## Zadanie 2: JWT — wykorzystanie podatności oraz realizacja poprawki

Testowany adres `/jwt/none` (`none-send-token` w Postmanie) był podatny na atak polegający na użyciu w sfałszowanym żetonie JWT algorytmu podpisu "none". Poniżej opisany jest przebieg ataku oraz zastosowana poprawka.

### Podsumowanie przeprowadzonego ataku

#### Oryginalny żeton JWT

Poniższy żeton został otrzymany w wyniku odpytania adresu `/jwt` (`none-obtain-token` w Postmanie):

```jwt
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IlVzZXIiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.q7JruwCJviRhS7d9N9oNj4g5Mquze46w9WoJvdd_qGM
```

```json
{
  "alg": "HS256",
  "typ": "JWT"
}
.
{
  "account": "Bob",
  "role": "User",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
.
Podpis: `0xABB26BBB0089BE24614BB77D37DA0D8F883932ABB37B8EB0F56A09BDD76A18`
```

Zrzut ekranu potwierdzający pomyślne wygenerowanie żetonu:

![JWT_generated](https://github.com/Dove6/TBO-lab3/assets/24943032/faf40937-db35-42e1-a2d1-85bc12ae4eef)

Powyższy żeton pozwalał na uwierzytelnienie się jako użytkownik o roli "User", co pokazuje poniższy zrzut ekranu:

![JWT_init](https://github.com/Dove6/TBO-lab3/assets/24943032/051397ad-01d8-41cf-bec8-23c93dddb56e)

#### Zaakceptowany przez serwer sfałszowany żeton

```jwt
eyJhbGciOiJub25lIn0.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.
```

```json
{
  "alg": "none"
}
.
{
  "account": "Bob",
  "role": "Administrator",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
.
```

Zrzut ekranu potwierdzający otrzymanie od serwera oczekiwanej odpowiedzi:

![JWT_final](https://github.com/Dove6/TBO-lab3/assets/24943032/ae52ec2e-0e26-46e5-8475-e5a3314c1942)

### Eksperymenty ze sfałszowanymi żetonami - kroki pośrednie (nie obejmuje kroków wyżej opisanych)

<details>
<summary>Eksperymenty ze sfałszowanymi żetonami</summary>

#### Krok 1: oryginalny podpis, zmieniona rola

Pierwszy eksperyment polegał na prostej podmianie części JWT zawierającej informację o roli (z użyciem narzędzi https://www.base64decode.org/ i https://www.base64encode.org/).

```json
{
  "alg": "HS256",
  "typ": "JWT"
}
.
{
  "account": "Bob",
  "role": "Administrator",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
.
Podpis: `0xABB26BBB0089BE24614BB77D37DA0D8F883932ABB37B8EB0F56A09BDD76A18`
```

```jwt
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.q7JruwCJviRhS7d9N9oNj4g5Mquze46w9WoJvdd_qGM
```

Jak widać na poniższym zrzucie ekranu, żeton nie został zaakceptowany przez serwer ze względu na niezgodność podpisanej sumy kontrolnej z treścią ciała JSON (błąd `invalid signature`):

![JWT_exp1](https://github.com/Dove6/TBO-lab3/assets/24943032/c7e05af9-f339-467c-907a-236d7da66ddd)

#### Krok 2: zmieniona rola, zmieniony podpis

Kolejny eksperyment wykorzystywał narzędzie https://jwt.io/ zarówno do podmiany ciała JWT, jak i wygenerowania nowego, spójnego z treścią podpisu.

```json
{
  "alg": "HS256",
  "typ": "JWT"
}
.
{
  "account": "Bob",
  "role": "Administrator",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
.
Podpis: `0x59EE9622788DEDC422B9490EADB70DC50C677D26EE1CB642DB56A6C339D44D92`
```

```jwt
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.We6WIniN7cQiuUkOrbcNxQxnfSbuHLZC21amwznUTZI
```

Wykorzystany klucz (losowy) nie był jednak zgodny z kluczem wykorzystywanym przez serwer, co spowodowało otrzymanie komunikatu błędu `invalid signature`:

![JWT_exp2](https://github.com/Dove6/TBO-lab3/assets/24943032/21b4c313-866c-49da-b7b6-7ccfc6af0653)

#### Krok 3: zmieniona rola, brak podpisu

Następny eksperyment polegał na pozbyciu się całej ostatniej części (zawierającej podpisaną sumę kontrolną).

```json
{
  "alg": "HS256",
  "typ": "JWT"
}
.
{
  "account": "Bob",
  "role": "Administrator",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
.
```

```jwt
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.
```

W nagłówku JWT cały czas była jednak obecna informacja o wykorzystaniu algorytmu HS256, a więc serwer wciąż oczekiwał obecności podpisu (błąd `jwt signature is required`):

![JWT_exp3](https://github.com/Dove6/TBO-lab3/assets/24943032/e64b941d-3ebb-468b-8cdd-aa699994f39a)

#### Krok 4: zmieniona rola, brak podpisu, brak kropki

Ostatni eksperyment miał na celu sprawdzenie, czy wymagana jest ostatnia z kropek rozdzielających żeton JWT na trzy części.

```json
{
  "alg": "HS256",
  "typ": "JWT"
}
.
{
  "account": "Bob",
  "role": "Administrator",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
```

```jwt
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0
```

Okazało się, że kropka jest wymagana. Bez jej zastosowania serwer zwracał informację o błędzie wewnętrznym:

![JWT_exp4](https://github.com/Dove6/TBO-lab3/assets/24943032/ed6dc06c-1a92-4e6e-aa80-dd93e0a64ac8)

</details>

### Zaimplementowana poprawka

Poprawka polegała na usunięciu algorytmu `none` z algorytmów podpisu żetonu JWT wspieranych przez metodę obsługującą adres `/jwt/none`. Lista wspieranych algorytmów znajdowała się w wywołaniu `JWT.verify` ([plik `app.json`, linia 34](https://github.com/Dove6/TBO-lab3/pull/1/files#diff-e2ea8dd1bc470a1f80d71eb2034206ea173977590d3ea67941709f3c7dc2dcf1)), w zestawie opcji podanych jako trzeci argument, konkretnie w opcji `algorithms`. Po zastosowaniu poprawki lista zawierała już tylko algorytm `HS256`.

Poprawność działania poprawki udowodniona jest poniższym zrzutem ekranu:

![JWT_fix](https://github.com/Dove6/TBO-lab3/assets/24943032/3f5ad136-39ab-4976-aaa8-d96cabfd93f1)

Przedstawia on wiadomość błędu `invalid algorithm` - reakcję serwera na wykorzystanie uprzednio przyjętego przez niego sfałszowanego żetonu wykorzystującego algorytm `none`:

```jwt
eyJhbGciOiJub25lIn0.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IkFkbWluaXN0cmF0b3IiLCJpYXQiOjE3MDIwMzM0MDUsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.
```

```json
{
  "alg": "none"
}
.
{
  "account": "Bob",
  "role": "Administrator",
  "iat": 1702033405,
  "aud": "https://127.0.0.1/jwt/none"
}
.
```